### PR TITLE
Add Refresh On Init option and Refresh OSC preset

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,11 @@ instance.prototype.init = function () {
 	self.init_osc();
 	debug = self.debug;
 	log   = self.log;
+
+	if (self.config.refreshOnInit) {
+		debug("Sending control surface refresh action to " + self.config.host);
+		self.system.emit('osc_send', self.config.host, self.config.port, '/action/41743');
+	}
 };
 
 // Return config fields for web config
@@ -74,6 +79,13 @@ instance.prototype.config_fields = function () {
 			width:   3,
 			tooltip: 'The port REAPER is sending OSC to',
 			regex:   self.REGEX_SIGNED_NUMBER
+		},
+		{
+			type:    'checkbox',
+			id:      'refreshOnInit',
+			label:   'Refresh On Start',
+			tooltip: 'If enabled, a "Control surface: Refresh all surfaces" command will be sent to reaper on start.',
+			default: false,
 		}
 	]
 };

--- a/presets.js
+++ b/presets.js
@@ -188,6 +188,25 @@ module.exports = {
 						options: self.getFeedbackDefaults('clickStatus')
 					}
 				]
+			},
+			{
+				category: 'General',
+				label:    'Refresh all control surfaces',
+				bank:     {
+					style:   'text',
+					text:    'Refresh OSC',
+					size:    '7',
+					color:   '16777215',
+					bgcolor: '0',
+				},
+				actions:  [
+					{
+						action:  'custom_action',
+						options: {
+							action_cmd_id: '41743'
+						}
+					}
+				]
 			}
 
 


### PR DESCRIPTION
Per #8, adds an option to the Reaper module that allows a user to configure whether a `Control surface: Refresh all surfaces` Reaper action should be sent automatically when the module is initialized.

Also added a `Refresh OSC` preset to send the same message manually:
![image](https://user-images.githubusercontent.com/19542938/117535005-ed940700-b047-11eb-92ec-08cb4cb362cf.png)

I don't have an actual Streamdeck to test with yet, but have tested it works ok with the emulator.