### PR TITLE
Add some Track and Track FX actions/vars/feedbacks

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -36,6 +36,13 @@ This module connects to the Cockos Reaper software.
 * Track Unmute
 * Track Unsolo
 * Track Unarm
+* Track Mute (toggle)
+* Track Solo (toggle)
+* Track Arm (toggle)
+* Track FX Bypass
+* Track FX Open UI
+* Track FX Unbypass
+* Track FX Close UI
 * Custom Action
 
 ### Available feedbacks
@@ -47,6 +54,11 @@ Feedbacks are available to reflect the state of the following actions:
 * Forward
 * Repeat
 * Click/Metronome
+* Track Mute
+* Track Solo
+* Track Arm
+* Track FX Active
+* Track FX UI Open
 * Custom feedback based on an OSC message and its value
 
 ### Available presets

--- a/HELP.md
+++ b/HELP.md
@@ -57,6 +57,8 @@ Feedbacks are available to reflect the state of the following actions:
 * Track Mute
 * Track Solo
 * Track Arm
+* Track Monitoring
+* Track Selected
 * Track FX Active
 * Track FX UI Open
 * Custom feedback based on an OSC message and its value

--- a/HELP.md
+++ b/HELP.md
@@ -39,6 +39,10 @@ This module connects to the Cockos Reaper software.
 * Track Mute (toggle)
 * Track Solo (toggle)
 * Track Arm (toggle)
+* Track Select
+* Track Deselect
+* Track Monitoring Enable
+* Track Monitoring Disable
 * Track FX Bypass
 * Track FX Open UI
 * Track FX Unbypass

--- a/actions.js
+++ b/actions.js
@@ -110,6 +110,107 @@ module.exports = {
 					}
 				]
 			},
+			'track_mute_toggle':   {
+				label:   'Track Mute Toggle',
+				options: [
+					{
+						type:    'textinput',
+						label:   'Track',
+						id:      'track',
+						default: "1"
+					}
+				]
+			},
+			'track_solo_toggle':   {
+				label:   'Track Solo Toggle',
+				options: [
+					{
+						type:    'textinput',
+						label:   'Track',
+						id:      'track',
+						default: "1"
+					}
+				]
+			},
+			'track_arm_toggle':   {
+				label:   'Track Record Arm Toggle',
+				options: [
+					{
+						type:    'textinput',
+						label:   'Track',
+						id:      'track',
+						default: "1"
+					}
+				]
+			},
+			'track_fx_bypass':   {
+				label:   'Track Fx Bypass',
+				options: [
+					{
+						type:    'textinput',
+						label:   'Track',
+						id:      'track',
+						default: "1"
+					},
+					{
+						type:    'textinput',
+						label:   'Fx',
+						id:      'fx',
+						default: "1"
+					}
+				]
+			},
+			'track_fx_openui':   {
+				label:   'Track Fx Open UI',
+				options: [
+					{
+						type:    'textinput',
+						label:   'Track',
+						id:      'track',
+						default: "1"
+					},
+					{
+						type:    'textinput',
+						label:   'Fx',
+						id:      'fx',
+						default: "1"
+					}
+				]
+			},
+			'track_fx_unbypass':   {
+				label:   'Track Fx Unbypass',
+				options: [
+					{
+						type:    'textinput',
+						label:   'Track',
+						id:      'track',
+						default: "1"
+					},
+					{
+						type:    'textinput',
+						label:   'Fx',
+						id:      'fx',
+						default: "1"
+					}
+				]
+			},
+			'track_fx_closeui':   {
+				label:   'Track Fx Close UI',
+				options: [
+					{
+						type:    'textinput',
+						label:   'Track',
+						id:      'track',
+						default: "1"
+					},
+					{
+						type:    'textinput',
+						label:   'Fx',
+						id:      'fx',
+						default: "1"
+					}
+				]
+			},
 			'custom_action': {
 				label:   'Custom Action',
 				options: [
@@ -222,7 +323,31 @@ module.exports = {
 				args.push({type: 'i', value: '0'});
 				cmd = '/track/' + opt.track + '/recarm';
 				break;
-
+			case 'track_mute_toggle':
+				cmd = '/track/' + opt.track + '/mute/toggle';
+				break;
+			case 'track_solo_toggle':
+				cmd = '/track/' + opt.track + '/solo/toggle';
+				break;
+			case 'track_arm_toggle':
+				cmd = '/track/' + opt.track + '/recarm/toggle';
+				break;
+			case 'track_fx_bypass':
+				args.push({type: 'i', value: '0'});
+				cmd = '/track/' + opt.track + '/fx/' + opt.fx + '/bypass';
+				break;
+			case 'track_fx_openui':
+				args.push({type: 'i', value: '1'});
+				cmd = '/track/' + opt.track + '/fx/' + opt.fx + '/openui';
+				break;
+			case 'track_fx_unbypass':
+				args.push({type: 'i', value: '1'}); // 1 to unbypass
+				cmd = '/track/' + opt.track + '/fx/' + opt.fx + '/bypass';
+				break;
+			case 'track_fx_closeui':
+				args.push({type: 'i', value: '0'});
+				cmd = '/track/' + opt.track + '/fx/' + opt.fx + '/openui';
+				break;
 			case 'custom_action':
 				// Integer & String commandID's are sent differently...
 				if (parseInt(opt.action_cmd_id) > 0) {

--- a/actions.js
+++ b/actions.js
@@ -143,6 +143,50 @@ module.exports = {
 					}
 				]
 			},
+			'track_select':     {
+				label:   'Track Select',
+				options: [
+					{
+						type:    'textinput',
+						label:   'Track',
+						id:      'track',
+						default: "1"
+					}
+				]
+			},
+			'track_deselect':     {
+				label:   'Track Deselect',
+				options: [
+					{
+						type:    'textinput',
+						label:   'Track',
+						id:      'track',
+						default: "1"
+					}
+				]
+			},
+			'track_monitor_enable':     {
+				label:   'Track Monitoring Enable',
+				options: [
+					{
+						type:    'textinput',
+						label:   'Track',
+						id:      'track',
+						default: "1"
+					}
+				]
+			},
+			'track_monitor_disable':     {
+				label:   'Track Monitoring Disable',
+				options: [
+					{
+						type:    'textinput',
+						label:   'Track',
+						id:      'track',
+						default: "1"
+					}
+				]
+			},
 			'track_fx_bypass':   {
 				label:   'Track Fx Bypass',
 				options: [
@@ -323,31 +367,59 @@ module.exports = {
 				args.push({type: 'i', value: '0'});
 				cmd = '/track/' + opt.track + '/recarm';
 				break;
+
 			case 'track_mute_toggle':
 				cmd = '/track/' + opt.track + '/mute/toggle';
 				break;
+
 			case 'track_solo_toggle':
 				cmd = '/track/' + opt.track + '/solo/toggle';
 				break;
+
 			case 'track_arm_toggle':
 				cmd = '/track/' + opt.track + '/recarm/toggle';
 				break;
+
+			case 'track_select':
+				args.push({type: 'i', value: '1'});
+				cmd = '/track/' + opt.track + '/select';
+				break;
+		
+			case 'track_deselect':
+				args.push({type: 'i', value: '0'});
+				cmd = '/track/' + opt.track + '/select';
+				break;
+
+			case 'track_monitor_enable':
+				args.push({type: 'i', value: '1'});
+				cmd = '/track/' + opt.track + '/monitor';
+				break;
+
+			case 'track_monitor_disable':
+				args.push({type: 'i', value: '0'});
+				cmd = '/track/' + opt.track + '/monitor';
+				break;
+
 			case 'track_fx_bypass':
 				args.push({type: 'i', value: '0'});
 				cmd = '/track/' + opt.track + '/fx/' + opt.fx + '/bypass';
 				break;
+
 			case 'track_fx_openui':
 				args.push({type: 'i', value: '1'});
 				cmd = '/track/' + opt.track + '/fx/' + opt.fx + '/openui';
 				break;
+
 			case 'track_fx_unbypass':
 				args.push({type: 'i', value: '1'}); // 1 to unbypass
 				cmd = '/track/' + opt.track + '/fx/' + opt.fx + '/bypass';
 				break;
+
 			case 'track_fx_closeui':
 				args.push({type: 'i', value: '0'});
 				cmd = '/track/' + opt.track + '/fx/' + opt.fx + '/openui';
 				break;
+
 			case 'custom_action':
 				// Integer & String commandID's are sent differently...
 				if (parseInt(opt.action_cmd_id) > 0) {

--- a/feedback.js
+++ b/feedback.js
@@ -295,6 +295,18 @@ module.exports = {
 				}
 			}
 		}
+
+		// Track Feedbacks
+		feedbacks['track_mute'] = self.createBooleanTrackFeedback('mute', 'Change color when a track is muted', 'Change color when a track is muted');
+		feedbacks['track_solo'] = self.createBooleanTrackFeedback('solo', 'Change color when a track is soloed', 'Change color when a track is soloed');
+		feedbacks['track_recarm'] = self.createBooleanTrackFeedback('recarm', 'Change color when a track is armed for recording', 'Change color when a track is armed for recording');
+		feedbacks['track_select'] = self.createBooleanTrackFeedback('select', 'Change color when a track is selected', 'Change color when a track is selected');
+		feedbacks['track_monitor'] = self.createBooleanTrackFeedback('monitor', 'Change color when monitoring is enabled for a track', 'Change color when monitoring is enabled for a track');
+
+		// Track FX Feedbacks
+		feedbacks['track_fx_bypass'] = self.createBooleanTrackFxFeedback('bypass', 'Change color when an FX is active', 'Change color when an FX is active');
+		feedbacks['track_fx_openui'] = self.createBooleanTrackFxFeedback('openui', 'Change color when an FX UI window is open', 'Change color when an FX UI window is open');
+		
 		return feedbacks;
 	},
 
@@ -305,5 +317,89 @@ module.exports = {
 			p[c[0]] = c[1];
 			return p;
 		}, {})
+	},
+
+	createBooleanTrackFeedback(propertyName, label, description)
+	{
+		var self = this;
+
+		return {
+			label:       label,
+			description: description,
+			options:     [
+				{
+					type:    'colorpicker',
+					label:   'Foreground color',
+					id:      'fg',
+					default: self.rgb(255, 255, 255)
+				},
+				{
+					type:    'colorpicker',
+					label:   'Background color',
+					id:      'bg',
+					default: self.rgb(0, 255, 0)
+				},
+				{
+					type:     'number',
+					label:    'Track Number',
+					id:       'trackNumber',
+					default:  1
+
+				}
+			], callback: (feedback, bank) => {
+				var self = this;
+
+				var track = self.getTrack(feedback.options.trackNumber);
+
+				if (track !== undefined && track[propertyName] === true)
+				{
+					return {color: feedback.options.fg, bgcolor: feedback.options.bg};
+				}
+			}
+		}
+	},
+
+	createBooleanTrackFxFeedback(propertyName, label, description) {
+		var self = this;
+
+		return {
+			label:       label,
+			description: description,
+			options:     [
+				{
+					type:    'colorpicker',
+					label:   'Foreground color',
+					id:      'fg',
+					default: self.rgb(255, 255, 255)
+				},
+				{
+					type:    'colorpicker',
+					label:   'Background color',
+					id:      'bg',
+					default: self.rgb(0, 255, 0)
+				},
+				{
+					type:     'number',
+					label:    'Track Number',
+					id:       'trackNumber',
+					default:  1
+				},
+				{
+					type:     'number',
+					label:    'FX Number',
+					id:       'fxNumber',
+					default:   1
+				}
+			], callback: (feedback, bank) => {
+				var self = this;
+
+				var fx = self.getTrackFx(feedback.options.trackNumber, feedback.options.fxNumber);
+
+				if (fx !== undefined && fx[propertyName] === true)
+				{
+					return {color: feedback.options.fg, bgcolor: feedback.options.bg};
+				}
+			}
+		}
 	}
 }

--- a/feedback.js
+++ b/feedback.js
@@ -271,12 +271,17 @@ module.exports = {
 	},
 
 	// Condenses feedback options to an object containing id and default value alone for all feedback options
-	getFeedbackDefaults(feedbackType) {
+	getFeedbackDefaultOptions(feedbackType) {
 		var self = this
 		return self.getFeedbacks()[feedbackType].options.map(e => [e.id, e.default]).reduce(function (p, c) {
 			p[c[0]] = c[1];
 			return p;
 		}, {})
+	},
+
+	getFeedbackDefaultStyle(feedbackType) {
+		var self = this
+		return self.getFeedbacks()[feedbackType].style;
 	},
 
 	createBooleanTrackFeedback(propertyName, label, description)

--- a/feedback.js
+++ b/feedback.js
@@ -13,8 +13,8 @@ module.exports = {
 
 		feedbacks['playStatus']    = {
 			type:        'boolean',
-			label:       'Change colors based on Play/Pause status',
-			description: 'Change colors based on Play/Pause status',
+			label:       'Change style based on Play/Pause status',
+			description: 'Change style based on Play/Pause status',
 			style:       {
 				color:	 self.rgb(255, 255, 255),
 				bgcolor: self.rgb(0, 183, 0)
@@ -41,8 +41,8 @@ module.exports = {
 		}
 		feedbacks['stopStatus']    = {
 			type:        'boolean',
-			label:       'Change colors based on Stop status',
-			description: 'Change colors based on Stop status',
+			label:       'Change style based on Stop status',
+			description: 'Change style based on Stop status',
 			style:       {
 				color:	 self.rgb(255, 255, 255),
 				bgcolor: self.rgb(76, 76, 76)
@@ -68,8 +68,8 @@ module.exports = {
 		}
 		feedbacks['recordStatus']  = {
 			type:        'boolean',
-			label:       'Change colors based on Record status',
-			description: 'Change colors based on Record status',
+			label:       'Change style based on Record status',
+			description: 'Change style based on Record status',
 			style:       {
 				color:	 self.rgb(255, 255, 255),
 				bgcolor: self.rgb(183, 0, 0)
@@ -95,8 +95,8 @@ module.exports = {
 		}
 		feedbacks['rewindStatus']  = {
 			type:        'boolean',
-			label:       'Change colors based on Rewind status',
-			description: 'Change colors based on Rewind status',
+			label:       'Change style based on Rewind status',
+			description: 'Change style based on Rewind status',
 			style:       {
 				color:	 self.rgb(255, 255, 255),
 				bgcolor: self.rgb(249, 199, 0)
@@ -122,8 +122,8 @@ module.exports = {
 		}
 		feedbacks['forwardStatus'] = {
 			type:        'boolean',
-			label:       'Change colors based on Fast Forward status',
-			description: 'Change colors based on Fast Forward status',
+			label:       'Change style based on Fast Forward status',
+			description: 'Change style based on Fast Forward status',
 			style:       {
 				color:	 self.rgb(255, 255, 255),
 				bgcolor: self.rgb(249, 199, 0)
@@ -150,8 +150,8 @@ module.exports = {
 
 		feedbacks['repeatStatus'] = {
 			type:        'boolean',
-			label:       'Change colors based on Repeat status',
-			description: 'Change colors based on Repeat status',
+			label:       'Change style based on Repeat status',
+			description: 'Change style based on Repeat status',
 			style:       {
 				color:	 self.rgb(255, 255, 255),
 				bgcolor: self.rgb(153, 0, 153)
@@ -178,8 +178,8 @@ module.exports = {
 
 		feedbacks['clickStatus'] = {
 			type:        'boolean',
-			label:       'Change colors based on Click status',
-			description: 'Change colors based on Click status',
+			label:       'Change style based on Click status',
+			description: 'Change style based on Click status',
 			style:       {
 				color:	 self.rgb(255, 255, 255),
 				bgcolor: self.rgb(11, 138, 179)
@@ -206,8 +206,8 @@ module.exports = {
 
 		feedbacks['customMessage'] = {
 			type:        'boolean',
-			label:       'Change colors based on a custom OSC message',
-			description: 'Change colors based on a custom OSC message',
+			label:       'Change style based on a custom OSC message',
+			description: 'Change style based on a custom OSC message',
 			style:       {
 				color:	 self.rgb(255, 255, 255),
 				bgcolor: self.rgb(0, 255, 0)
@@ -257,15 +257,15 @@ module.exports = {
 		}
 
 		// Track Feedbacks
-		feedbacks['track_mute'] = self.createBooleanTrackFeedback('mute', 'Change color when a track is muted', 'Change color when a track is muted');
-		feedbacks['track_solo'] = self.createBooleanTrackFeedback('solo', 'Change color when a track is soloed', 'Change color when a track is soloed');
-		feedbacks['track_recarm'] = self.createBooleanTrackFeedback('recarm', 'Change color when a track is armed for recording', 'Change color when a track is armed for recording');
-		feedbacks['track_select'] = self.createBooleanTrackFeedback('select', 'Change color when a track is selected', 'Change color when a track is selected');
-		feedbacks['track_monitor'] = self.createBooleanTrackFeedback('monitor', 'Change color when monitoring is enabled for a track', 'Change color when monitoring is enabled for a track');
+		feedbacks['track_mute'] = self.createBooleanTrackFeedback('mute', 'Change style when a track is muted', 'Change style when a track is muted');
+		feedbacks['track_solo'] = self.createBooleanTrackFeedback('solo', 'Change style when a track is soloed', 'Change style when a track is soloed');
+		feedbacks['track_recarm'] = self.createBooleanTrackFeedback('recarm', 'Change style when a track is armed for recording', 'Change style when a track is armed for recording');
+		feedbacks['track_select'] = self.createBooleanTrackFeedback('select', 'Change style when a track is selected', 'Change style when a track is selected');
+		feedbacks['track_monitor'] = self.createBooleanTrackFeedback('monitor', 'Change style when monitoring is enabled for a track', 'Change style when monitoring is enabled for a track');
 
 		// Track FX Feedbacks
-		feedbacks['track_fx_bypass'] = self.createBooleanTrackFxFeedback('bypass', 'Change color when an FX is active', 'Change color when an FX is active');
-		feedbacks['track_fx_openui'] = self.createBooleanTrackFxFeedback('openui', 'Change color when an FX UI window is open', 'Change color when an FX UI window is open');
+		feedbacks['track_fx_bypass'] = self.createBooleanTrackFxFeedback('bypass', 'Change style when an FX is active', 'Change style when an FX is active');
+		feedbacks['track_fx_openui'] = self.createBooleanTrackFxFeedback('openui', 'Change style when an FX UI window is open', 'Change style when an FX UI window is open');
 		
 		return feedbacks;
 	},

--- a/feedback.js
+++ b/feedback.js
@@ -12,21 +12,14 @@ module.exports = {
 		var feedbacks = {}
 
 		feedbacks['playStatus']    = {
+			type:        'boolean',
 			label:       'Change colors based on Play/Pause status',
 			description: 'Change colors based on Play/Pause status',
+			style:       {
+				color:	 self.rgb(255, 255, 255),
+				bgcolor: self.rgb(0, 183, 0)
+			},
 			options:     [
-				{
-					type:    'colorpicker',
-					label:   'Foreground color',
-					id:      'fg',
-					default: self.rgb(255, 255, 255)
-				},
-				{
-					type:    'colorpicker',
-					label:   'Background color',
-					id:      'bg',
-					default: self.rgb(0, 183, 0)
-				},
 				{
 					type:    'dropdown',
 					label:   'Status',
@@ -40,26 +33,21 @@ module.exports = {
 			],
 			callback: (feedback, bank) => {
 				if (this.playStatus === feedback.options.playPause) {
-					return {color: feedback.options.fg, bgcolor: feedback.options.bg}
+					return true;
 				}
+
+				return false;
 			}
 		}
 		feedbacks['stopStatus']    = {
+			type:        'boolean',
 			label:       'Change colors based on Stop status',
 			description: 'Change colors based on Stop status',
+			style:       {
+				color:	 self.rgb(255, 255, 255),
+				bgcolor: self.rgb(76, 76, 76)
+			},
 			options:     [
-				{
-					type:    'colorpicker',
-					label:   'Foreground color',
-					id:      'fg',
-					default: self.rgb(255, 255, 255)
-				},
-				{
-					type:    'colorpicker',
-					label:   'Background color',
-					id:      'bg',
-					default: self.rgb(76, 76, 76)
-				},
 				{
 					type:    'dropdown',
 					label:   'Status',
@@ -72,26 +60,21 @@ module.exports = {
 				}
 			], callback: (feedback, bank) => {
 				if (this.stopStatus === feedback.options.stopPlay) {
-					return {color: feedback.options.fg, bgcolor: feedback.options.bg}
+					return true;
 				}
+
+				return false;
 			}
 		}
 		feedbacks['recordStatus']  = {
+			type:        'boolean',
 			label:       'Change colors based on Record status',
 			description: 'Change colors based on Record status',
+			style:       {
+				color:	 self.rgb(255, 255, 255),
+				bgcolor: self.rgb(183, 0, 0)
+			},
 			options:     [
-				{
-					type:    'colorpicker',
-					label:   'Foreground color',
-					id:      'fg',
-					default: self.rgb(255, 255, 255)
-				},
-				{
-					type:    'colorpicker',
-					label:   'Background color',
-					id:      'bg',
-					default: self.rgb(183, 0, 0)
-				},
 				{
 					type:    'dropdown',
 					label:   'Status',
@@ -104,26 +87,21 @@ module.exports = {
 				}
 			], callback: (feedback, bank) => {
 				if (this.recordStatus === feedback.options.recordOrNot) {
-					return {color: feedback.options.fg, bgcolor: feedback.options.bg}
+					return true;
 				}
+
+				return false;
 			}
 		}
 		feedbacks['rewindStatus']  = {
+			type:        'boolean',
 			label:       'Change colors based on Rewind status',
 			description: 'Change colors based on Rewind status',
+			style:       {
+				color:	 self.rgb(255, 255, 255),
+				bgcolor: self.rgb(249, 199, 0)
+			},
 			options:     [
-				{
-					type:    'colorpicker',
-					label:   'Foreground color',
-					id:      'fg',
-					default: self.rgb(255, 255, 255)
-				},
-				{
-					type:    'colorpicker',
-					label:   'Background color',
-					id:      'bg',
-					default: self.rgb(249, 199, 0)
-				},
 				{
 					type:    'dropdown',
 					label:   'Status',
@@ -136,26 +114,21 @@ module.exports = {
 				}
 			], callback: (feedback, bank) => {
 				if (this.rewindStatus === feedback.options.rewindOrNot) {
-					return {color: feedback.options.fg, bgcolor: feedback.options.bg}
+					return true;
 				}
+
+				return false;
 			}
 		}
 		feedbacks['forwardStatus'] = {
+			type:        'boolean',
 			label:       'Change colors based on Fast Forward status',
 			description: 'Change colors based on Fast Forward status',
+			style:       {
+				color:	 self.rgb(255, 255, 255),
+				bgcolor: self.rgb(249, 199, 0)
+			},
 			options:     [
-				{
-					type:    'colorpicker',
-					label:   'Foreground color',
-					id:      'fg',
-					default: self.rgb(255, 255, 255)
-				},
-				{
-					type:    'colorpicker',
-					label:   'Background color',
-					id:      'bg',
-					default: self.rgb(249, 199, 0)
-				},
 				{
 					type:    'dropdown',
 					label:   'Status',
@@ -168,27 +141,22 @@ module.exports = {
 				}
 			], callback: (feedback, bank) => {
 				if (this.forwardStatus === feedback.options.forwardOrNot) {
-					return {color: feedback.options.fg, bgcolor: feedback.options.bg}
+					return true;
 				}
+
+				return false;
 			}
 		}
 
 		feedbacks['repeatStatus'] = {
+			type:        'boolean',
 			label:       'Change colors based on Repeat status',
 			description: 'Change colors based on Repeat status',
+			style:       {
+				color:	 self.rgb(255, 255, 255),
+				bgcolor: self.rgb(153, 0, 153)
+			},
 			options:     [
-				{
-					type:    'colorpicker',
-					label:   'Foreground color',
-					id:      'fg',
-					default: self.rgb(255, 255, 255)
-				},
-				{
-					type:    'colorpicker',
-					label:   'Background color',
-					id:      'bg',
-					default: self.rgb(153, 0, 153)
-				},
 				{
 					type:    'dropdown',
 					label:   'Status',
@@ -201,27 +169,22 @@ module.exports = {
 				}
 			], callback: (feedback, bank) => {
 				if (this.repeatStatus === feedback.options.repeatOrNot) {
-					return {color: feedback.options.fg, bgcolor: feedback.options.bg}
+					return true;
 				}
+
+				return false;
 			}
 		}
 
 		feedbacks['clickStatus'] = {
+			type:        'boolean',
 			label:       'Change colors based on Click status',
 			description: 'Change colors based on Click status',
+			style:       {
+				color:	 self.rgb(255, 255, 255),
+				bgcolor: self.rgb(11, 138, 179)
+			},
 			options:     [
-				{
-					type:    'colorpicker',
-					label:   'Foreground color',
-					id:      'fg',
-					default: self.rgb(255, 255, 255)
-				},
-				{
-					type:    'colorpicker',
-					label:   'Background color',
-					id:      'bg',
-					default: self.rgb(11, 138, 179)
-				},
 				{
 					type:    'dropdown',
 					label:   'Status',
@@ -234,27 +197,22 @@ module.exports = {
 				}
 			], callback: (feedback, bank) => {
 				if (this.clickStatus === feedback.options.clickOrNot) {
-					return {color: feedback.options.fg, bgcolor: feedback.options.bg}
+					return true;
 				}
+
+				return false;
 			}
 		}
 
 		feedbacks['customMessage'] = {
+			type:        'boolean',
 			label:       'Change colors based on a custom OSC message',
 			description: 'Change colors based on a custom OSC message',
+			style:       {
+				color:	 self.rgb(255, 255, 255),
+				bgcolor: self.rgb(0, 255, 0)
+			},
 			options:     [
-				{
-					type:    'colorpicker',
-					label:   'Foreground color',
-					id:      'fg',
-					default: self.rgb(255, 255, 255)
-				},
-				{
-					type:    'colorpicker',
-					label:   'Background color',
-					id:      'bg',
-					default: self.rgb(0, 255, 0)
-				},
 				{
 					type:    'textinput',
 					label:   'Message',
@@ -291,8 +249,10 @@ module.exports = {
 					}
 				});
 				if (foundFeedback !== undefined) {
-					return {color: feedback.options.fg, bgcolor: feedback.options.bg}
+					return true;
 				}
+
+				return false;
 			}
 		}
 

--- a/feedback.js
+++ b/feedback.js
@@ -324,27 +324,19 @@ module.exports = {
 		var self = this;
 
 		return {
+			type:        'boolean',
 			label:       label,
 			description: description,
+			style:       {
+				color:	 self.rgb(255, 255, 255),
+				bgcolor: self.rgb(0, 255, 0)
+			},
 			options:     [
-				{
-					type:    'colorpicker',
-					label:   'Foreground color',
-					id:      'fg',
-					default: self.rgb(255, 255, 255)
-				},
-				{
-					type:    'colorpicker',
-					label:   'Background color',
-					id:      'bg',
-					default: self.rgb(0, 255, 0)
-				},
 				{
 					type:     'number',
 					label:    'Track Number',
 					id:       'trackNumber',
 					default:  1
-
 				}
 			], callback: (feedback, bank) => {
 				var self = this;
@@ -353,8 +345,10 @@ module.exports = {
 
 				if (track !== undefined && track[propertyName] === true)
 				{
-					return {color: feedback.options.fg, bgcolor: feedback.options.bg};
+					return true;
 				}
+
+				return false;
 			}
 		}
 	},
@@ -363,21 +357,14 @@ module.exports = {
 		var self = this;
 
 		return {
+			type:        'boolean',
 			label:       label,
 			description: description,
+			style:       {
+				color:	 self.rgb(255, 255, 255),
+				bgcolor: self.rgb(0, 255, 0)
+			},
 			options:     [
-				{
-					type:    'colorpicker',
-					label:   'Foreground color',
-					id:      'fg',
-					default: self.rgb(255, 255, 255)
-				},
-				{
-					type:    'colorpicker',
-					label:   'Background color',
-					id:      'bg',
-					default: self.rgb(0, 255, 0)
-				},
 				{
 					type:     'number',
 					label:    'Track Number',
@@ -397,8 +384,10 @@ module.exports = {
 
 				if (fx !== undefined && fx[propertyName] === true)
 				{
-					return {color: feedback.options.fg, bgcolor: feedback.options.bg};
+					return true;
 				}
+
+				return false;
 			}
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -133,6 +133,8 @@ instance.prototype.init_osc = function () {
 		}
 	});
 
+	self.messageHandlers = self.getMessageHandlers();
+
 	self.listener.on("message", function (message) {
 			if (self.customMessageStatus === undefined) {
 				self.customMessageStatus = {}
@@ -152,117 +154,12 @@ instance.prototype.init_osc = function () {
 				}
 			});
 
-			if (message.address === '/play') {
-				if (message.args.length >= 0) {
-					var togglePlayStatus = message.args[0].value;
-					if (typeof togglePlayStatus === "number") {
-						if (togglePlayStatus === 1) {
-							self.playStatus = "Playing";
-						} else {
-							self.playStatus = "Paused";
-						}
-						self.setVariable('playStatus', self.playStatus);
-						self.checkFeedbacks('playStatus');
-						debug("togglePlayStatus is", togglePlayStatus)
-						debug("playStatus is", self.playStatus)
-					}
-				}
-			}
-			if (message.address === '/stop') {
-				if (message.args.length >= 0) {
-					var toggleStopStatus = message.args[0].value;
-					if (typeof toggleStopStatus === "number") {
-						if (toggleStopStatus === 1) {
-							self.stopStatus = "Stopped";
-						} else {
-							self.stopStatus = "Playing";
-						}
-						self.setVariable('stopStatus', self.stopStatus);
-						self.checkFeedbacks('stopStatus');
-						debug("toggleStopStatus is", toggleStopStatus)
-						debug("stopStatus is", self.stopStatus)
-					}
-				}
-			}
-			if (message.address === '/record') {
-				if (message.args.length >= 0) {
-					var toggleRecordStatus = message.args[0].value;
-					if (typeof toggleRecordStatus === "number") {
-						if (toggleRecordStatus === 1) {
-							self.recordStatus = "Recording";
-						} else {
-							self.recordStatus = "Not Recording";
-						}
-						self.setVariable('recordStatus', self.recordStatus);
-						self.checkFeedbacks('recordStatus');
-						debug("toggleRecordStatus is", toggleRecordStatus)
-						debug("recordStatus is", self.recordStatus)
-					}
-				}
-			}
-			if (message.address === '/rewind') {
-				if (message.args.length >= 0) {
-					var toggleRewindStatus = message.args[0].value;
-					if (typeof toggleRewindStatus === "number") {
-						if (toggleRewindStatus === 1) {
-							self.rewindStatus = "Rewinding";
-						} else {
-							self.rewindStatus = "Not Rewinding";
-						}
-						self.setVariable('rewindStatus', self.rewindStatus);
-						self.checkFeedbacks('rewindStatus');
-						debug("toggleRewindStatus is", toggleRewindStatus)
-						debug("rewindStatus is", self.rewindStatus)
-					}
-				}
-			}
-			if (message.address === '/forward') {
-				if (message.args.length >= 0) {
-					var toggleForwardStatus = message.args[0].value;
-					if (typeof toggleForwardStatus === "number") {
-						if (toggleForwardStatus === 1) {
-							self.forwardStatus = "Forwarding";
-						} else {
-							self.forwardStatus = "Not Forwarding";
-						}
-						self.setVariable('forwardStatus', self.forwardStatus);
-						self.checkFeedbacks('forwardStatus');
-						debug("toggleForwardStatus is", toggleForwardStatus)
-						debug("forwardStatus is", self.forwardStatus)
-					}
-				}
-			}
-			if (message.address === '/click') {
-				if (message.args.length >= 0) {
-					var toggleClickStatus = message.args[0].value;
-					if (typeof toggleClickStatus === "number") {
-						if (toggleClickStatus === 1) {
-							self.clickStatus = "Active";
-						} else {
-							self.clickStatus = "Inactive";
-						}
-						self.setVariable('clickStatus', self.clickStatus);
-						self.checkFeedbacks('clickStatus');
-						debug("toggleClickStatus is", toggleClickStatus)
-						debug("clickStatus is", self.clickStatus)
-					}
-				}
-			}
-			if (message.address === '/repeat') {
-				if (message.args.length >= 0) {
-					var toggleRepeatStatus = message.args[0].value;
-					if (typeof toggleRepeatStatus === "number") {
-						if (toggleRepeatStatus === 1) {
-							self.repeatStatus = "Active";
-						} else {
-							self.repeatStatus = "Inactive";
-						}
-						self.setVariable('repeatStatus', self.repeatStatus);
-						self.checkFeedbacks('repeatStatus');
-						debug("toggleRepeatStatus is", toggleRepeatStatus)
-						debug("repeatStatus is", self.repeatStatus)
-					}
-				}
+			var addressParts = message.address.split('/');
+			var messageType = addressParts[1];
+
+			if (self.messageHandlers[messageType] !== undefined)
+			{
+				self.messageHandlers[messageType](addressParts, message.args);
 			}
 		}
 	)
@@ -278,6 +175,114 @@ instance.prototype.init_feedbacks = function () {
 	var self      = this
 	var feedbacks = self.getFeedbacks();
 	self.setFeedbackDefinitions(feedbacks)
+}
+
+instance.prototype.getMessageHandlers = function()
+{
+	var self = this;
+
+	var trackHandlers = self.getTrackMessageHandlers();
+
+	return {
+		play:    (addressParts, args) => self.handleBinaryMessage('playStatus', args, self.valueConverters.play),
+		stop:    (addressParts, args) => self.handleBinaryMessage('stopStatus', args, self.valueConverters.stop),
+		record:  (addressParts, args) => self.handleBinaryMessage('recordStatus', args, self.valueConverters.record),
+		rewind:  (addressParts, args) => self.handleBinaryMessage('rewindStatus', args, self.valueConverters.rewind),
+		forward: (addressParts, args) => self.handleBinaryMessage('forwardStatus', args, self.valueConverters.forward),
+		click:   (addressParts, args) => self.handleBinaryMessage('clickStatus', args, self.valueConverters.click),
+		repeat:  (addressParts, args) => self.handleBinaryMessage('repeatStatus', args, self.valueConverters.repeat),
+		track:   (addressParts, args) => self.handleTrackMessage(addressParts, args, trackHandlers)
+	}
+}
+
+instance.prototype.getTrackMessageHandlers = function() {
+	var self = this;
+
+	var trackFxHandlers = self.getTrackFxMessageHandlers();
+
+	return {
+		mute:    (trackNumber, addressParts, args) => self.handleBinaryTrackMessage('mute', trackNumber, addressParts, args, self.valueConverters.trackMute),
+		solo:    (trackNumber, addressParts, args) => self.handleBinaryTrackMessage('solo', trackNumber, addressParts, args, self.valueConverters.trackSolo),
+		recarm:  (trackNumber, addressParts, args) => self.handleBinaryTrackMessage('recarm', trackNumber, addressParts, args, self.valueConverters.trackRecArm),
+		select:  (trackNumber, addressParts, args) => self.handleBinaryTrackMessage('select', trackNumber, addressParts, args, self.valueConverters.trackSelect),
+		name:    (trackNumber, addressParts, args) => {
+			var self = this;
+
+			self.setTrackProperty(trackNumber, 'name', args[0].value);
+		},
+		monitor: (trackNumber, addressParts, args) => self.handleBinaryTrackMessage('monitor', trackNumber, addressParts, args, self.valueConverters.trackMonitor),
+		fx:      (trackNumber, addressParts, args) => self.handleTrackFxMessage(trackNumber, addressParts[4], addressParts, args, trackFxHandlers)
+	};
+}
+
+instance.prototype.getTrackFxMessageHandlers = function() {
+	var self = this;
+
+	return {
+		bypass: (trackNumber, fxNumber, addressParts, args) => self.handleBinaryTrackFxMessage('bypass', trackNumber, fxNumber, args, self.valueConverters.trackFxBypass),
+		name:   (trackNumber, fxNumber, addressParts, args) => self.setTrackFxProperty(trackNumber, fxNumber, 'name', args[0].value),
+		openui: (trackNumber, fxNumber, addressParts, args) => self.handleBinaryTrackFxMessage('openui', trackNumber, fxNumber, args, self.valueConverters.trackFxOpenUi)
+	}
+}
+
+instance.prototype.handleBinaryMessage = function(variableName, args, valueConverter) {
+    var self = this;
+
+	if (args.length >= 0) {
+		var value = args[0].value;
+		if (typeof value === "number") {
+			var textValue = valueConverter !== undefined ? valueConverter(value) : value.toString();
+
+			self[variableName] = textValue
+			self.setVariable(variableName, textValue);
+			self.checkFeedbacks(variableName);
+			self.debug("message " + variableName + " value is", value)
+			self.debug(variableName + " is", self[variableName])
+		}
+	}
+}
+
+// TODO: Handle messages regarding selected track  (has no track number)
+// /track/[trackNumber]/[messageType]
+instance.prototype.handleTrackMessage = function (addressParts, args, handlers) {
+	var trackNumber = parseInt(addressParts[2]);
+	var messageType = addressParts[3];
+
+	if (handlers[messageType] !== undefined)
+	{
+		handlers[messageType](trackNumber, addressParts, args);
+	}
+}
+
+instance.prototype.handleBinaryTrackMessage = function(propertyName, trackNumber, addressParts, args, valueConverter) {
+	var self = this;
+
+	// Toggles can be ignored
+	if (addressParts[4] === 'toggle')
+	{
+		return;
+	}
+
+	self.setTrackProperty(trackNumber, propertyName, args[0].value === 1, valueConverter);
+	self.checkFeedbacks('track_' + propertyName);
+}
+
+// /track/[trackNumber]/fx/[fxNumber]/[messageType]
+instance.prototype.handleTrackFxMessage = function(trackNumber, fxNumber, addressParts, args, handlers){
+	var messageType = addressParts[5];
+
+	if (handlers[messageType] !== undefined)
+	{
+		handlers[messageType](trackNumber, fxNumber, addressParts, args);
+	}
+}
+
+instance.prototype.handleBinaryTrackFxMessage = function(propertyName, trackNumber, fxNumber, args, valueConverter)
+{
+	var self = this;
+	
+	self.setTrackFxProperty(trackNumber, fxNumber, propertyName, args[0].value === 1, valueConverter);
+	self.checkFeedbacks('track_fx_' + propertyName);
 }
 
 instance_skel.extendedBy(instance);

--- a/index.js
+++ b/index.js
@@ -285,5 +285,20 @@ instance.prototype.handleBinaryTrackFxMessage = function(propertyName, trackNumb
 	self.checkFeedbacks('track_fx_' + propertyName);
 }
 
+instance.GetUpgradeScripts = function() {
+	return [
+		instance_skel.CreateConvertToBooleanFeedbackUpgradeScript({
+			'playStatus': true,
+			'stopStatus': true,
+			'recordStatus': true,
+			'rewindStatus': true,
+			'forwardStatus': true,
+			'repeatStatus': true,
+			'clickStatus': true,
+			'customMessage': true,
+		})
+	]
+}
+
 instance_skel.extendedBy(instance);
 exports = module.exports = instance;

--- a/presets.js
+++ b/presets.js
@@ -31,7 +31,8 @@ module.exports = {
 				feedbacks: [
 					{
 						type:    'playStatus',
-						options: self.getFeedbackDefaults('playStatus')
+						options: self.getFeedbackDefaultOptions('playStatus'),
+						style: self.getFeedbackDefaultStyle('playStatus')
 					}
 				]
 			},
@@ -55,7 +56,8 @@ module.exports = {
 				feedbacks: [
 					{
 						type:    'stopStatus',
-						options: self.getFeedbackDefaults('stopStatus')
+						options: self.getFeedbackDefaultOptions('stopStatus'),
+						style: self.getFeedbackDefaultStyle('stopStatus')
 					}
 				]
 			},
@@ -79,7 +81,8 @@ module.exports = {
 				feedbacks: [
 					{
 						type:    'recordStatus',
-						options: self.getFeedbackDefaults('recordStatus')
+						options: self.getFeedbackDefaultOptions('recordStatus'),
+						style: self.getFeedbackDefaultStyle('recordStatus')
 					}
 				]
 			},
@@ -108,7 +111,8 @@ module.exports = {
 				feedbacks:       [
 					{
 						type:    'rewindStatus',
-						options: self.getFeedbackDefaults('rewindStatus')
+						options: self.getFeedbackDefaultOptions('rewindStatus'),
+						style: self.getFeedbackDefaultStyle('rewindStatus')
 					}
 				]
 			},
@@ -137,7 +141,8 @@ module.exports = {
 				feedbacks:       [
 					{
 						type:    'forwardStatus',
-						options: self.getFeedbackDefaults('forwardStatus')
+						options: self.getFeedbackDefaultOptions('forwardStatus'),
+						style: self.getFeedbackDefaultStyle('forwardStatus')
 					}
 				]
 			},
@@ -161,7 +166,8 @@ module.exports = {
 				feedbacks: [
 					{
 						type:    'repeatStatus',
-						options: self.getFeedbackDefaults('repeatStatus')
+						options: self.getFeedbackDefaultOptions('repeatStatus'),
+						style: self.getFeedbackDefaultStyle('repeatStatus')
 					}
 				]
 			},
@@ -185,7 +191,8 @@ module.exports = {
 				feedbacks: [
 					{
 						type:    'clickStatus',
-						options: self.getFeedbackDefaults('clickStatus')
+						options: self.getFeedbackDefaultOptions('clickStatus'),
+						style: self.getFeedbackDefaultStyle('clickStatus')
 					}
 				]
 			}

--- a/variables.js
+++ b/variables.js
@@ -17,6 +17,8 @@ module.exports = {
 		var repeatStatus         = 'Inactive';
 		var clickStatus          = 'Inactive';
 		self.customMessageStatus = {};
+		self.tracks              = {};
+		self.valueConverters     = self.getValueConverters();
 
 		// Create a variable containing only needed information about the used "custom message" feedbacks
 		self.customMessages = self.getAllFeedbacks().reduce(function (filtered, feedback) {
@@ -92,7 +94,170 @@ module.exports = {
 			self.setVariable('customFeedback' + index, self.customMessageStatus[cm.id]);
 		});
 
+		self.addTrackVariables(variables, 8);
+
 		return variables;
 
+	},
+
+	addTrackVariables(variables, numberOfTracks)
+	{
+		var self = this;
+
+		for (i = 0; i < 8; i++)
+		{
+			var trackNumber = i+1;
+
+			var track = {
+				mute:    false,
+				solo:    false,
+				recarm:  false,
+				select:  false,
+				name:    'Track ' + trackNumber,
+				monitor: false
+			}
+
+			self.tracks[trackNumber] = track;
+
+			self.addTrackVariable(variables, trackNumber, 'mute', 'Muted', self.valueConverters.trackMute(track.mute));
+			self.addTrackVariable(variables, trackNumber, 'solo', 'Soloed', self.valueConverters.trackSolo(track.solo));
+			self.addTrackVariable(variables, trackNumber, 'recarm', 'Armed for record', self.valueConverters.trackRecArm(track.recarm));
+			self.addTrackVariable(variables, trackNumber, 'select', 'Selected', self.valueConverters.trackSelect(track.select));
+			self.addTrackVariable(variables, trackNumber, 'name', 'Name', track.name);
+			self.addTrackVariable(variables, trackNumber, 'monitor', 'Monitoring', self.valueConverters.trackMonitor(track.monitor));
+
+			for (j = 0; j  < numberOfTracks; j++)
+			{
+				var fxNumber = j+1;
+
+				var fx = {
+					bypass: false,
+					name:   'FX' + fxNumber,
+					openui: false
+				};
+
+				track['fx' + fxNumber] = fx;
+
+				self.addTrackFxVariable(variables, trackNumber, fxNumber, 'bypass', 'Bypass', self.valueConverters.trackFxBypass(fx.bypass));
+				self.addTrackFxVariable(variables, trackNumber, fxNumber, 'name', 'Name', fx.name);
+				self.addTrackFxVariable(variables, trackNumber, fxNumber, 'openui', 'UI Open', self.valueConverters.trackFxOpenUi(fx.openui));
+			}
+		}
+	},
+
+	setTrackProperty(trackNumber, propertyName, value, valueConverter)
+	{
+		var self = this;
+
+		if (self.tracks[trackNumber] === undefined)
+		{
+			self.tracks[trackNumber] = {};
+		}
+
+		self.tracks[trackNumber][propertyName] = value;
+		self.debug('track `' + trackNumber + '` property `' + propertyName + '` set to:', value);
+
+		var variableValue = valueConverter !== undefined ? valueConverter(value) : value;
+
+		self.setVariable(self.getTrackVariableName(trackNumber, propertyName), variableValue);
+	},
+
+	setTrackFxProperty(trackNumber, fxNumber, propertyName, value, valueConverter)
+	{
+		var self = this;
+
+		var fxPropertyName = 'fx' + fxNumber;
+
+		if (self.tracks[trackNumber] === undefined)
+		{
+			self.tracks[trackNumber] = {};
+		}
+
+		if (self.tracks[trackNumber][fxPropertyName] === undefined)
+		{
+			self.tracks[trackNumber][fxPropertyName] = {};
+		}
+
+		self.tracks[trackNumber][fxPropertyName][propertyName] = value;
+		self.debug('track `' + trackNumber + '` FX `' + fxNumber + '` property `' + propertyName + '` set to:', value);
+
+		var variableValue = valueConverter !== undefined ? valueConverter(value) : value;
+		self.setVariable(self.getTrackFxVariableName(trackNumber, fxNumber, propertyName), variableValue);
+	},
+
+	addTrackVariable(variables, trackNumber, propertyName, label, defaultValue)
+	{
+		var self         = this;
+		var variableName = self.getTrackVariableName(trackNumber, propertyName);
+
+		variables.push({
+			label: 'Track ' + trackNumber + ' ' + label,
+			name: variableName
+		});
+
+		self.setVariable(variableName, defaultValue);
+	},
+
+	addTrackFxVariable(variables, trackNumber, fxNumber, propertyName, label, defaultValue)
+	{
+		var self         = this;
+		var variableName = self.getTrackFxVariableName(trackNumber, fxNumber, propertyName);
+
+		variables.push({
+			label: 'Track ' + trackNumber + ' FX' + fxNumber + ' ' + label,
+			name: variableName
+		});
+
+		self.setVariable(variableName, defaultValue);
+	},
+
+	getTrackVariableName(trackNumber, propertyName){
+		var propertyCapitalized = propertyName.charAt(0).toUpperCase() + propertyName.slice(1);
+
+		return 'track' + trackNumber + propertyCapitalized;
+	},
+
+	getTrackFxVariableName(trackNumber, fxNumber, propertyName)
+	{
+		var self                = this;
+		var propertyCapitalized = propertyName.charAt(0).toUpperCase() + propertyName.slice(1);
+
+		return self.getTrackVariableName(trackNumber, 'Fx' + fxNumber + propertyCapitalized);
+	},
+
+	getTrack(trackNumber)
+	{
+		var self = this;
+		return self.tracks[trackNumber];
+	},
+
+	getTrackFx(trackNumber, fxNumber)
+	{
+		var self = this;
+		var track = self.getTrack(trackNumber);
+
+		if (track !== undefined)
+		{
+			return track['fx' + fxNumber];
+		}
+	},
+
+	getValueConverters() {
+		return {
+			play:          (value) => value ? "Playing" : "Paused",
+		    stop:          (value) => value ? "Stopped" : "Playing",
+		    record:        (value) => value ? "Recording" : "Not Recording",
+		    rewind:        (value) => value ? "Rewinding" : "Not Rewinding",
+		    forward:       (value) => value ? "Forwarding" : "Not Forwarding",
+		    click:         (value) => value ? "Active" : "Inactive",
+		    repeat:        (value) => value ? "Active" : "Inactive",
+		    trackMute:     (value) => value ? "Muted" : "Not Muted",
+		    trackSolo:     (value) => value ? "Soloed" : "Not Soloed",
+		    trackRecArm:   (value) => value ? "Record Armed" : "Record Disarmed",
+		    trackSelect:   (value) => value ? "Selected" : "Not Selected",
+		    trackMonitor:  (value) => value ? "Monitoring" : "Not Monitoring",
+		    trackFxBypass: (value) => value ? "Active" : "Bypassed", // For some reason Reaper sends a 1 when not bypassed.
+			trackFxOpenUi: (value) => value ? "Open" : "Closed"
+		}
 	}
 }


### PR DESCRIPTION
PR for #5

Adds the following:

| Property | Variable | Feedback | Action(s) |
|-------------|:---------:|:----------:|:-----:|
| Track Mute | ✅ | ✅ | Toggle* |
| Track Solo  | ✅ | ✅ | Toggle* |
| Track Record Arm | ✅ | ✅ | Toggle* |
| Track Selected | ✅ | ✅ | Select / Deselect |
| Track Name | ✅ | ❌ | - |
| Track Monitoring | ✅ | ✅ | Enable / Disable |
| Track Fx Bypass | ✅ | ✅ | Bypass / Unbypass |
| Track Fx UI Open | ✅ | ✅ | Open / Close |
| Track Fx Name | ✅ | ❌ | - |

_*This is the Reaper `/toggle` message for these properties_

Currently supports 8 tracks and 8 FX per track (matching the default Reaper OSC pattern settings).

Here's an example:
![image](https://user-images.githubusercontent.com/19542938/120875868-218c2900-c602-11eb-8191-7899a3f48ca3.png)

Displays 4 tracks with buttons for select, record arm, solo, and mute. Also has a Tuner button which opens/closes ReaTune on the guitar track, and     a Delay button that toggles bypass on Valhalla Supermassive on the guitar track.