### PR TITLE
Add configuration options for number of tracks and FX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cockos-reaper",
-	"version": "2.1.1",
+	"version": "2.2.0",
 	"main": "dist/index.js",
 	"scripts": {
 		"prepare": "husky install",

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,8 @@ export interface ModuleConfig {
 	port: number
 	feedbackPort: number
 	refreshOnInit: boolean
+	numberOfTracks: number
+	numberOfFx: number
 }
 
 export function GetConfigFields(): SomeCompanionConfigField[] {
@@ -51,6 +53,26 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
 			width: 3,
 			tooltip: 'If enabled, a "Control surface: Refresh all surfaces" command will be sent to reaper on start.',
 			default: true,
+		},
+		{
+			type: 'number',
+			id: 'numberOfTracks',
+			label: 'Number of Tracks',
+			width: 3,
+			tooltip: 'Sets the number of tracks per bank',
+			min: 1,
+			max: 512,
+			default: 8,
+		},
+		{
+			type: 'number',
+			id: 'numberOfFx',
+			label: 'Number of FX',
+			width: 3,
+			tooltip: 'Sets the number of FX per track',
+			min: 1,
+			max: 512,
+			default: 8,
 		},
 	]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,10 @@ class ControllerInstance extends InstanceBase<ModuleConfig> {
 		reaperConfig.remoteAddress = config.host
 		reaperConfig.remotePort = config.port
 
+		// Device Setup
+		reaperConfig.numberOfTracks = config.numberOfTracks
+		reaperConfig.numberOfFx = config.numberOfFx
+
 		reaperConfig.afterMessageReceived = (message, handled) => {
 			this.handleCustomMessages(message, handled)
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { CustomMessageFeedbacks, FeedbackBindings, FeedbackId, GetFeedbacksList 
 import { GetActionsList } from './actions'
 import { LogLevel, OscMessage, Reaper, ReaperConfiguration } from 'reaper-osc'
 import { GetVariableDefinitions, ReaperProperty } from './variables'
-import { CreateUseInvertForFeedbacksUpgradeScript } from './upgrades'
+import { CreateNumberOfTracksDefaultsUpgradeScript, CreateUseInvertForFeedbacksUpgradeScript } from './upgrades'
 
 class ControllerInstance extends InstanceBase<ModuleConfig> {
 	private _reaper: Reaper | null
@@ -205,4 +205,5 @@ runEntrypoint(ControllerInstance, [
 		[FeedbackId.RepeatStatus]: { optionId: 'repeatOrNot', trueValue: 'Active' },
 		[FeedbackId.ClickStatus]: { optionId: 'clickOrNot', trueValue: 'Active' },
 	}),
+	CreateNumberOfTracksDefaultsUpgradeScript(),
 ])

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ class ControllerInstance extends InstanceBase<ModuleConfig> {
 
 		this._reaper = new Reaper(reaperConfig)
 
-		this.bindVariables()
+		this.bindVariables(config.numberOfTracks, config.numberOfFx)
 
 		this.log('debug', `Reaper Configuration: ${JSON.stringify(reaperConfig, null, 2)}`)
 
@@ -138,8 +138,8 @@ class ControllerInstance extends InstanceBase<ModuleConfig> {
 		}
 	}
 
-	private bindVariables(): void {
-		const variables = GetVariableDefinitions()
+	private bindVariables(numberOfTracks: number, numberOfFx: number): void {
+		const variables = GetVariableDefinitions(numberOfTracks, numberOfFx)
 
 		const unsubscribes: Unsubscribe[] = []
 

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -35,6 +35,22 @@ export function CreateUseInvertForFeedbacksUpgradeScript(
 	}
 }
 
+export function CreateNumberOfTracksDefaultsUpgradeScript(): CompanionStaticUpgradeScript<ModuleConfig> {
+	return (_, props) => {
+		const { config } = props
+		if (config) {
+			config.numberOfTracks ??= 8
+			config.numberOfFx ??= 8
+		}
+
+		return {
+			updatedConfig: config,
+			updatedActions: [],
+			updatedFeedbacks: [],
+		}
+	}
+}
+
 export type BooleanFeedbackOption = {
 	optionId: string
 	trueValue: string

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -13,15 +13,15 @@ export type ReaperPropertyVariableDefinition = {
 	valueConverter?: (value: any) => any
 } & CompanionVariableDefinition
 
-export function GetVariableDefinitions(): ReaperPropertyVariableDefinition[] {
+export function GetVariableDefinitions(numberOfTracks: number, numberOfFx: number): ReaperPropertyVariableDefinition[] {
 	const variables: ReaperPropertyVariableDefinition[] = []
 
-	variables.push(...LegacyVariableDefinitions())
+	variables.push(...LegacyVariableDefinitions(numberOfTracks, numberOfFx))
 
 	return variables
 }
 
-function LegacyVariableDefinitions(): ReaperPropertyVariableDefinition[] {
+function LegacyVariableDefinitions(numberOfTracks: number, numberOfFx: number): ReaperPropertyVariableDefinition[] {
 	const variables: ReaperPropertyVariableDefinition[] = [
 		{
 			...LegacyTransportVariable('playStatus', 'Play Status', 'isPlaying'),
@@ -69,13 +69,15 @@ function LegacyVariableDefinitions(): ReaperPropertyVariableDefinition[] {
 				const minutes = Math.floor((value / 60) % 60)
 				const seconds = value % 60
 				// build up time string in h:mm:ss.mmm format with optional hours section
-				return `${hours > 0 ? hours + ':' + minutes.toString().padStart(2, '0') : minutes}:${seconds.toFixed(3).padStart(6, '0')}`
+				return `${hours > 0 ? hours + ':' + minutes.toString().padStart(2, '0') : minutes}:${seconds
+					.toFixed(3)
+					.padStart(6, '0')}`
 			},
 		},
 	]
 
-	for (let i = 0; i < 8; i++) {
-		const trackVariables = LegacyTrackVariables(i)
+	for (let i = 0; i < numberOfTracks; i++) {
+		const trackVariables = LegacyTrackVariables(i, numberOfFx)
 
 		variables.push(...trackVariables)
 	}
@@ -83,7 +85,7 @@ function LegacyVariableDefinitions(): ReaperPropertyVariableDefinition[] {
 	return variables
 }
 
-function LegacyTrackVariables(trackIndex: number): ReaperPropertyVariableDefinition[] {
+function LegacyTrackVariables(trackIndex: number, numberOfFx: number): ReaperPropertyVariableDefinition[] {
 	const variables: ReaperPropertyVariableDefinition[] = [
 		{
 			...LegacyTrackVariable(trackIndex, 'Mute', 'Muted', 'isMuted'),
@@ -110,7 +112,7 @@ function LegacyTrackVariables(trackIndex: number): ReaperPropertyVariableDefinit
 		},
 	]
 
-	for (let i = 0; i < 8; i++) {
+	for (let i = 0; i < numberOfFx; i++) {
 		const fxVariables = LegacyTrackFxVariables(trackIndex, i)
 
 		variables.push(...fxVariables)


### PR DESCRIPTION
Fixes #24

Adds two configuration options:
* Number of Tracks (per bank)
* Number of FX (per track)

These are defaulted to 8 when upgrading to maintain existing functionality.